### PR TITLE
Fix workflow syntax error in recommendation PR workflow

### DIFF
--- a/.github/workflows/create-recommendation-pr.yml
+++ b/.github/workflows/create-recommendation-pr.yml
@@ -74,8 +74,9 @@ jobs:
         if: inputs.photo != ''
         run: |
           # Extract file extension from filename or default to jpg
-          if [ -n "${{ inputs.photoFileName }}" ]; then
-            EXTENSION="${{ inputs.photoFileName }##*.}"
+          FILENAME="${{ inputs.photoFileName }}"
+          if [ -n "$FILENAME" ]; then
+            EXTENSION="${FILENAME##*.}"
           else
             EXTENSION="jpg"
           fi


### PR DESCRIPTION
Fixes the GitHub Actions workflow validation error by moving bash parameter expansion outside of GitHub Actions variable interpolation.

The workflow was failing with: Unexpected symbol in expression.

Changed from direct expansion to using an intermediate variable to avoid parsing conflicts.

🤖 Generated with Claude Code